### PR TITLE
Add importlib.util to list of imports.

### DIFF
--- a/picosnitch.py
+++ b/picosnitch.py
@@ -25,7 +25,7 @@ import functools
 import ipaddress
 import json
 import hashlib
-import importlib
+import importlib.util
 import multiprocessing
 import os
 import pickle


### PR DESCRIPTION
At least on my Gentoo Python 3.9 install, this import is needed
or I get the following error:

$ picosnitch start
Warning: picosnitch was run without root privileges, requesting root privileges
Traceback (most recent call last):
  File "/home/user/.local/bin/picosnitch", line 8, in <module>
    sys.exit(start_daemon())
  File "/home/user/.local/lib/python3.9/site-packages/picosnitch.py", line 1246, in start_daemon
    if importlib.util.find_spec("picosnitch"):
AttributeError: module 'importlib' has no attribute 'util'