### PR TITLE
hook fexit/inet_recvmsg and fexit/inet6_recvmsg instead of fexit/sock_recvmsg

### DIFF
--- a/src/picosnitch/bpf/picosnitch.bpf.c
+++ b/src/picosnitch/bpf/picosnitch.bpf.c
@@ -550,10 +550,15 @@ int BPF_PROG(inet6_sendmsg_ret, struct socket *sock, struct msghdr *msg, size_t 
     return trace_sendrecv(ctx, sk, msg, ret, 1);
 }
 
-// recv: hook the generic sock_recvmsg (socket, msg, flags).
-SEC("fexit/sock_recvmsg")
-int BPF_PROG(sock_recvmsg_ret, struct socket *sock, struct msghdr *msg, int flags, int ret)
-{
+// recv: hook inet_recvmsg / inet6_recvmsg, the per-family sendmsg dispatch.
+SEC("fexit/inet_recvmsg")
+int BPF_PROG(inet_recvmsg_ret, struct socket *sock, struct msghdr *msg, size_t size, int flags, int ret) {
+    struct sock *sk = BPF_CORE_READ(sock, sk);
+    return trace_sendrecv(ctx, sk, msg, ret, 0);
+}
+
+SEC("fexit/inet6_recvmsg")
+int BPF_PROG(inet6_recvmsg_ret, struct socket *sock, struct msghdr *msg, size_t size, int flags, int ret) {
     struct sock *sk = BPF_CORE_READ(sock, sk);
     return trace_sendrecv(ctx, sk, msg, ret, 0);
 }

--- a/src/picosnitch/subprocesses/monitor.py
+++ b/src/picosnitch/subprocesses/monitor.py
@@ -538,20 +538,20 @@ def run_monitor(config: Config, fan_fd: int, event_pipes: tuple, q_error: multip
         use_getaddrinfo_uprobe = True
     except Exception as e:
         q_error.put(f"BPF.attach_uprobe() failed for getaddrinfo: {e}, falling back to only using reverse DNS lookup")
-    # attach fexit network hooks: inet_sendmsg/inet6_sendmsg for send,
-    # sock_recvmsg for recv
+    # attach fexit network hooks: inet_sendmsg for send, inet_recvmsg for recv
     try:
         b.bpf_obj.attach_trace("inet_sendmsg_ret")
-        b.bpf_obj.attach_trace("sock_recvmsg_ret")
+        b.bpf_obj.attach_trace("inet_recvmsg_ret")
     except Exception as e:
         q_error.put(f"Failed to attach network monitoring programs: {e}")
         raise
-    # inet6_sendmsg is best-effort: absent on kernels built without IPv6, a
-    # missing hook only drops IPv6 send bytes
+    # inet6_sendmsg and inet6_recvmsg are best-effort: absent on kernels
+    # built without IPv6, a missing hook only drops IPv6 send bytes
     try:
         b.bpf_obj.attach_trace("inet6_sendmsg_ret")
+        b.bpf_obj.attach_trace("inet6_recvmsg_ret")
     except Exception as e:
-        q_error.put(f"BPF.attach_trace() failed for inet6_sendmsg: {e}, IPv6 send bytes will not be recorded")
+        q_error.put(f"BPF.attach_trace() failed for inet6 probes: {e}, IPv6 traffic will not be recorded")
 
     # callbacks for bpf events, read event and put into a pipe for run_primary
     def queue_lost(event, *args):


### PR DESCRIPTION
Sweet project! Took a little digging to get working on my system.

I believe this is the same issue as e925ab0 but for received data. Before this patch no incoming traffic was detected on my system and after this patch it works as expected.

```
❯ uname -a
Linux 7.1.2-3-cachyos #1 SMP PREEMPT_DYNAMIC Mon, 29 Jun 2026 14:34:33 +0000 x86_64 GNU/Linux
```